### PR TITLE
added support for bilingual mapfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,8 @@ script:
   - find . -type f -name "*.py" | xargs flake8
   - geomet-climate vrt generate
   - geomet-climate tileindex generate
-  - geomet-climate mapfile generate -l en -s WMS
-  - geomet-climate mapfile generate -l fr -s WMS
-  - geomet-climate mapfile generate -l en -s WCS
-  - geomet-climate mapfile generate -l fr -s WCS
+  - geomet-climate mapfile generate -s WMS
+  - geomet-climate mapfile generate -s WCS
   - mapserv -nh QUERY_STRING="map=$GEOMET_CLIMATE_BASEDIR/mapfile/geomet-climate-WMS-en.map&service=WMS&version=1.3.0&request=GetCapabilities" > $GEOMET_CLIMATE_BASEDIR/geomet-climate-WMS-1.3.0-capabilities-en.xml
   - mapserv -nh QUERY_STRING="map=$GEOMET_CLIMATE_BASEDIR/mapfile/geomet-climate-WMS-fr.map&lang=fr&service=WMS&version=1.3.0&request=GetCapabilities" > $GEOMET_CLIMATE_BASEDIR/geomet-climate-WMS-1.3.0-capabilities-fr.xml
   - mapserv -nh QUERY_STRING="map=$GEOMET_CLIMATE_BASEDIR/mapfile/geomet-climate-WCS-en.map&service=WCS&version=2.1.0&request=GetCapabilities" > $GEOMET_CLIMATE_BASEDIR/geomet-climate-WCS-2.0.1-capabilities-en.xml

--- a/README.md
+++ b/README.md
@@ -66,14 +66,14 @@ geomet-climate tileindex generate
 # generate tileindex for single layer
 geomet-climate tileindex generate --layer=CMIP5.SND.RCP26.FALL.ANO_PCTL50
 
-# generate mapfile for WMS (English)
-geomet-climate mapfile generate --language=en --service=WMS
+# generate mapfile for WMS
+geomet-climate mapfile generate --service=WMS
 
-# generate mapfile for WMS (English) with specific configuration for single layer
-geomet-climate mapfile generate --language=en --service=WMS --layer=CMIP5.SND.RCP26.FALL.ANO_PCTL50
+# generate mapfile for WMS with specific configuration for single layer
+geomet-climate mapfile generate --service=WMS --layer=CMIP5.SND.RCP26.FALL.ANO_PCTL50
 
-# generate mapfile for WCS (French)
-geomet-climate mapfile generate --language=fr --service=WCS
+# generate mapfile for WCS
+geomet-climate mapfile generate --service=WCS
 
 # run server
 geomet-climate serve  # server runs on port 8099
@@ -96,7 +96,7 @@ mapserv -nh QUERY_STRING="map=$GEOMET_CLIMATE_BASEDIR/mapfile/geomet-climate-WCS
 ### Running Tests
 
 ```bash
-. test/geomet-climate-test.env
+. tests/geomet-climate-test.env
 python setup.py test
 ```
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -10,17 +10,11 @@ geomet-climate vrt generate
 echo "Generating tileindexes"
 geomet-climate tileindex generate
 
-echo "Generating WMS (English)"
-geomet-climate mapfile generate -l en -s WMS
+echo "Generating WMS"
+geomet-climate mapfile generate -s WMS
 
-echo "Generating WMS (French)"
-geomet-climate mapfile generate -l fr -s WMS
-
-echo "Generating WCS (English)"
-geomet-climate mapfile generate -l en -s WCS
-
-echo "Generating WCS (French)"
-geomet-climate mapfile generate -l fr -s WCS
+echo "Generating WCS"
+geomet-climate mapfile generate -s WCS
 
 echo "Caching WMS (English)"
 mapserv -nh QUERY_STRING="map=$GEOMET_CLIMATE_BASEDIR/mapfile/geomet-climate-WMS-en.map&service=WMS&version=1.3.0&request=GetCapabilities" > $GEOMET_CLIMATE_BASEDIR/geomet-climate-WMS-1.3.0-capabilities-en.xml && mv -f $GEOMET_CLIMATE_BASEDIR/geomet-climate-WMS-1.3.0-capabilities-en.xml $GEOMET_CLIMATE_BASEDIR/mapfile

--- a/geomet_climate/wsgi.py
+++ b/geomet_climate/wsgi.py
@@ -53,6 +53,53 @@ SERVICE_EXCEPTION = '''<?xml version='1.0' encoding="UTF-8" standalone="no"?>
 </ServiceExceptionReport>'''
 
 
+def metadata_lang(m, l):
+    """
+    function to update the mapfile MAP metadata
+    keys in function of the lang of the request
+
+    :param m: mapfile object to update language
+    :param l: lang of the request
+    """
+
+    m.setMetaData('ows_address',
+                  m.getMetaData('ows_address_{}'.format(l)))
+    m.setMetaData('ows_contactperson',
+                  m.getMetaData('ows_contactperson_{}'.format(l)))
+    m.setMetaData('ows_city',
+                  m.getMetaData('ows_city_{}'.format(l)))
+    m.setMetaData('ows_country',
+                  m.getMetaData('ows_country_{}'.format(l)))
+    m.setMetaData('ows_keywordlist_http://purl.org/dc/terms/_items',
+                  m.getMetaData('ows_keywordlist_http://purl.org/dc/terms/_items_{}'.format(l))) # noqa
+    m.setMetaData('wms_attribution_title',
+                  m.getMetaData('wms_attribution_title_{}'.format(l)))
+    m.setMetaData('ows_contactinstructions',
+                  m.getMetaData('ows_contactinstructions_{}'.format(l)))
+    m.setMetaData('ows_contactposition',
+                  m.getMetaData('ows_contactposition_{}'.format(l)))
+    m.setMetaData('ows_contactorganization',
+                  m.getMetaData('ows_contactorganization_{}'.format(l)))
+    m.setMetaData('wms_attribution_onlineresource',
+                  m.getMetaData('wms_attribution_onlineresource_{}'.format(l)))
+    m.setMetaData('ows_onlineresource',
+                  m.getMetaData('ows_onlineresource_{}'.format(l)))
+    m.setMetaData('ows_abstract',
+                  m.getMetaData('ows_abstract_{}'.format(l)))
+    m.setMetaData('ows_service_onlineresource',
+                  m.getMetaData('ows_service_onlineresource_{}'.format(l)))
+    m.setMetaData('ows_title',
+                  m.getMetaData('ows_title_{}'.format(l)))
+    m.setMetaData('ows_hoursofservice',
+                  m.getMetaData('ows_hoursofservice_{}'.format(l)))
+    m.setMetaData('ows_stateorprovince',
+                  m.getMetaData('ows_stateorprovince_{}'.format(l)))
+    m.setMetaData('ows_keywordlist',
+                  m.getMetaData('ows_keywordlist_{}'.format(l)))
+    m.setMetaData('wcs_description',
+                  m.getMetaData('wcs_description_{}'.format(l)))
+
+
 def application(env, start_response):
     """WSGI application for WMS/WCS"""
     for key in MAPSERV_ENV:
@@ -97,8 +144,8 @@ def application(env, start_response):
     LOGGER.debug('language: {}'.format(lang))
 
     if layer is not None and ',' not in layer:
-        mapfile_ = '{}/mapfile/geomet-climate-{}-{}-{}.map'.format(
-            BASEDIR, service_, layer, lang)
+        mapfile_ = '{}/mapfile/geomet-climate-{}-{}.map'.format(
+            BASEDIR, service_, layer)
     if mapfile_ is None or not os.path.exists(mapfile_):
         mapfile_ = '{}/mapfile/geomet-climate-{}-{}.map'.format(
             BASEDIR, service_, lang)
@@ -123,9 +170,16 @@ def application(env, start_response):
             start_response('200 OK', [('Content-Type', 'application/xml')])
             with io.open(cached_caps, 'rb') as fh:
                 return [fh.read()]
-
-    LOGGER.debug('Loading mapfile: {}'.format(mapfile_))
-    mapfile = mapscript.mapObj(mapfile_)
+    else:
+        LOGGER.debug('Loading mapfile: {}'.format(mapfile_))
+        mapfile = mapscript.mapObj(mapfile_)
+        if request_ == 'GetCapabilities' and lang == 'fr':
+            metadata_lang(mapfile, lang)
+            layerobj = mapfile.getLayerByName(layer)
+            layerobj.setMetaData('ows_title',
+                                 layerobj.getMetaData('ows_title_{}'.format(lang))) # noqa
+            layerobj.setMetaData('ows_layer_group',
+                                 layerobj.getMetaData('ows_layer_group_{}'.format(lang))) # noqa
 
     mapscript.msIO_installStdoutToBuffer()
     request.loadParamsFromURL(env['QUERY_STRING'])

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -202,7 +202,7 @@ class GeoMetClimateTest(unittest.TestCase):
 
         self.assertTrue(os.path.isfile(out_file))
 
-    def test_gen_web_metadata_En(self):
+    def test_gen_web_metadata(self):
         """test mapfile MAP.WEB.METADATA section creation (En)"""
         url = 'https://fake.url/geomet-climate'
         mapfile = os.path.join(THISDIR,
@@ -210,35 +210,16 @@ class GeoMetClimateTest(unittest.TestCase):
         with io.open(mapfile) as fh:
             m = json.load(fh, object_pairs_hook=OrderedDict)
         c = self.cfg['metadata']
-        lang = 'en'
         services = ['wms', 'wcs']
 
         for service in services:
-            result = gen_web_metadata(m, c, lang, service, url)
+            result = gen_web_metadata(m, c, service, url)
             self.assertTrue(result['ows_extent'] == '-141,42,-52,84')
             self.assertTrue(result['ows_stateorprovince'] == 'Quebec')
             self.assertTrue(result['ows_country'] == 'Canada')
             self.assertTrue(result['ows_contactinstructions'] ==
                             'During hours of service')
-
-    def test_gen_web_metadata_Fr(self):
-        """test mapfile MAP.WEB.METADATA section creation (Fr)"""
-        url = 'https://fake.url/geomet-climate'
-        mapfile = os.path.join(THISDIR,
-                               '../geomet_climate/resources/mapfile-base.json')
-        with io.open(mapfile) as fh:
-            m = json.load(fh, object_pairs_hook=OrderedDict)
-        c = self.cfg['metadata']
-        lang = 'fr'
-        services = ['wms', 'wcs']
-
-        for service in services:
-            result = gen_web_metadata(m, c, lang, service, url)
-
-            self.assertTrue(result['ows_extent'] == '-141,42,-52,84')
-            self.assertTrue(result['ows_stateorprovince'] == u'Qu\xe9bec')
-            self.assertTrue(result['ows_country'] == 'Canada')
-            self.assertTrue(result['ows_contactinstructions'] ==
+            self.assertTrue(result['ows_contactinstructions_fr'] ==
                             'Durant les heures de service')
 
     def test_gen_layer_metadataurl(self):
@@ -263,50 +244,24 @@ class GeoMetClimateTest(unittest.TestCase):
                                                           '467a-496f-a71c-'
                                                           'fb0aad0171a8')
 
-    def test_gen_layer_En(self):
+    def test_gen_layer(self):
         """returns a list of mappyfile layer objects of layer (En)"""
-        lang = 'en'
         layer_name = 'CMIP5.TT.RCP26.SPRING.2021-2040_PCTL50'
         layer_info = self.cfg['layers'][layer_name]
         template_path = '/foo/bar/path'
-        ows_title = 'CMIP5 (Spring)- Projected average change in Air' \
-                    ' Temperature for 2021-2040 (50th percentile)'
-        ows_layer_group = '/CMIP5-based climate scenarios (CMIP5)' \
-                          '/Air temperature/RCP 2.6/Spring/2021-2040'
+        ows_title_en = 'CMIP5 (Spring)- Projected average change in Air' \
+                       ' Temperature for 2021-2040 (50th percentile)'
+        ows_layer_group_en = '/CMIP5-based climate scenarios (CMIP5)' \
+                             '/Air temperature/RCP 2.6/Spring/2021-2040'
+        ows_title_fr = u"CMIP5 (printemps)- Changement moyen projet\xe9 de " \
+                       u"la temp\xe9rature de l'air pour 2021 \xe0 2040 " \
+                       u"(50e percentile)"
+        ows_layer_group_fr = u"/Sc\xe9narios climatiques fond\xe9s sur " \
+                             u"CMIP5 (CMIP5)/Temp\xe9rature de l'air/" \
+                             u"RCP 2.6/Printemps/2021 \xe0 2040"
 
         result = gen_layer(layer_name, layer_info,
-                           lang,  template_path, service='WMS')
-        self.assertTrue(result[0]['projection'] == ['+proj=longlat'
-                                                    ' +datum=WGS84 +no_defs'])
-        self.assertTrue(result[0]['name'] == 'CMIP5.TT.RCP26.SPRING.'
-                                             '2021-2040_PCTL50')
-
-        print(result[0]['data'])
-
-        self.assertTrue(result[0]['data'] == 'tests/data/climate/'
-                                             'cmip5/netcdf/scenarios/RCP2.6/'
-                                             'seasonal/MAM/avg_20years/'
-                                             'CMIP5_rcp2.6_MAM_2021-2040_'
-                                             'latlon1x1_TEMP_pctl50_P1Y.nc')
-        self.assertTrue(result[0]['metadata']['ows_title'] == ows_title)
-        self.assertTrue(result[0]['metadata']['ows_layer_group'] ==
-                        ows_layer_group)
-
-    def test_gen_layer_Fr(self):
-        """returns a list of mappyfile layer objects of layer (Fr)"""
-        lang = 'fr'
-        layer_name = 'CMIP5.TT.RCP26.SPRING.2021-2040_PCTL50'
-        layer_info = self.cfg['layers'][layer_name]
-        template_path = '/foo/bar/path'
-        ows_title = u"CMIP5 (printemps)- Changement moyen projet\xe9 de " \
-                    u"la temp\xe9rature de l'air pour 2021 \xe0 2040 " \
-                    u"(50e percentile)"
-        ows_layer_group = u"/Sc\xe9narios climatiques fond\xe9s sur " \
-                          u"CMIP5 (CMIP5)/Temp\xe9rature de l'air/" \
-                          u"RCP 2.6/Printemps/2021 \xe0 2040"
-
-        result = gen_layer(layer_name, layer_info,
-                           lang,  template_path, service='WMS')
+                           template_path, service='WMS')
         self.assertTrue(result[0]['projection'] == ['+proj=longlat'
                                                     ' +datum=WGS84 +no_defs'])
         self.assertTrue(result[0]['name'] == 'CMIP5.TT.RCP26.SPRING.'
@@ -316,9 +271,12 @@ class GeoMetClimateTest(unittest.TestCase):
                                              'seasonal/MAM/avg_20years/'
                                              'CMIP5_rcp2.6_MAM_2021-2040_'
                                              'latlon1x1_TEMP_pctl50_P1Y.nc')
-        self.assertTrue(result[0]['metadata']['ows_title'] == ows_title)
+        self.assertTrue(result[0]['metadata']['ows_title'] == ows_title_en)
         self.assertTrue(result[0]['metadata']['ows_layer_group'] ==
-                        ows_layer_group)
+                        ows_layer_group_en)
+        self.assertTrue(result[0]['metadata']['ows_title_fr'] == ows_title_fr)
+        self.assertTrue(result[0]['metadata']['ows_layer_group_fr'] ==
+                        ows_layer_group_fr)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is how I would do a biligual mapfile: 

1. add _en and _fr for every metadata that needs to be in English and French
2. In the mapscript, for GetCapabilities only, replace the _en/_fr metadata with the one in the requested language

This avoids creating ~6000 mapfiles just for the En / Fr support.  I didn't notice any impact on performances. 

Also this is only done for GetCapabilities requests. For GetMap, GetFeatureInfo, WCS Describve coverage and Getcaoverage this substitution does not need to be done.

The code still creates a English and a separate French whole mapfile because we are caching those using the mapserv command.

It now also takes half the time to create the mapfiles too. 

I think this is a good test for doing the same process for geomet2 giving it would save processing power and means the English and French mapfiles will always have the same information which is not necessarily the case at the moment because the En and Fr mapfiles are created half an hour apart (GeoMet2).

CC @alexandreleroux 