### PR TITLE
Split Indices legends to solve legend name error

### DIFF
--- a/geomet-climate.yml
+++ b/geomet-climate.yml
@@ -639,30 +639,30 @@ layer_templates:
 
   gsc: &template_gsc
     type: RASTER
-    classgroup: GSC_GSW_GSO
+    classgroup: GSC
     name_en: Length of growing season for cool season crops
     name_fr: Durée de la saison de croissance des cultures de saison fraiche
     bounds: [50, 100, 150, 200, 250, 300, 350]
     styles:
-    - mapserv/class/gsc_gsw_gso.json
+    - mapserv/class/gsc.json
 
   gsw: &template_gsw
     type: RASTER
-    classgroup: GSC_GSW_GSO
+    classgroup: GSW
     name_en: Length of growing season for warm season crops
     name_fr: Durée de la saison de croissance des cultures de saison chaude
     bounds: [50, 100, 150, 200, 250, 300, 350]
     styles:
-    - mapserv/class/gsc_gsw_gso.json
+    - mapserv/class/gsw.json
 
   gso: &template_gso
     type: RASTER
-    classgroup: GSC_GSW_GSO
+    classgroup: GSO
     name_en: Length of growing season for overwintering crops
     name_fr: Durée de la saison de croissance des cultures d’hiver
     bounds: [50, 100, 150, 200, 250, 300, 350]
     styles:
-    - mapserv/class/gsc_gsw_gso.json
+    - mapserv/class/gso.json
 
   hdd: &template_hdd
     type: RASTER

--- a/geomet_climate/resources/mapserv/class/gsc.json
+++ b/geomet_climate/resources/mapserv/class/gsc.json
@@ -1,0 +1,114 @@
+[
+  {
+    "__type__": "class",
+    "name": "50",
+    "group": "GSC",
+    "expression": "([pixel] >= 50 and [pixel] < 51)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        255,
+        115
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "50 — 100",
+    "group": "GSC",
+    "expression": "([pixel] >= 51 AND [pixel] < 100)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        224,
+        224,
+        0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "100 — 150",
+    "group": "GSC",
+    "expression": "([pixel] >= 100 AND [pixel] <= 150 )",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        212,
+        0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "150 — 200",
+    "group": "GSC",
+    "expression": "([pixel] >= 150 AND [pixel] < 200)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        171,
+        0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "200 — 250",
+    "group": "GSC",
+    "expression": "([pixel] >= 200 AND [pixel] < 250)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        128,
+        0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "250 — 300",
+    "group": "GSC",
+    "expression": "([pixel] >= 250 AND [pixel] < 300)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        84,
+        0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "300 — 350",
+    "group": "GSC",
+    "expression": "([pixel] >= 300 AND [pixel] < 350)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        43,
+        0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": ">= 350",
+    "group": "GSC",
+    "expression": "([pixel] >= 350)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        0,
+        0
+      ]
+    }
+  }
+]

--- a/geomet_climate/resources/mapserv/class/gso.json
+++ b/geomet_climate/resources/mapserv/class/gso.json
@@ -1,0 +1,114 @@
+[
+  {
+    "__type__": "class",
+    "name": "50",
+    "group": "GSO",
+    "expression": "([pixel] >= 50 and [pixel] < 51)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        255,
+        115
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "50 — 100",
+    "group": "GSO",
+    "expression": "([pixel] >= 51 AND [pixel] < 100)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        224,
+        224,
+        0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "100 — 150",
+    "group": "GSO",
+    "expression": "([pixel] >= 100 AND [pixel] <= 150 )",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        212,
+        0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "150 — 200",
+    "group": "GSO",
+    "expression": "([pixel] >= 150 AND [pixel] < 200)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        171,
+        0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "200 — 250",
+    "group": "GSO",
+    "expression": "([pixel] >= 200 AND [pixel] < 250)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        128,
+        0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "250 — 300",
+    "group": "GSO",
+    "expression": "([pixel] >= 250 AND [pixel] < 300)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        84,
+        0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "300 — 350",
+    "group": "GSO",
+    "expression": "([pixel] >= 300 AND [pixel] < 350)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        43,
+        0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": ">= 350",
+    "group": "GSO",
+    "expression": "([pixel] >= 350)",
+    "style": {
+      "__type__": "style",
+      "color": [
+        255,
+        0,
+        0
+      ]
+    }
+  }
+]

--- a/geomet_climate/resources/mapserv/class/gsw.json
+++ b/geomet_climate/resources/mapserv/class/gsw.json
@@ -2,7 +2,7 @@
   {
     "__type__": "class",
     "name": "50",
-    "group": "GSC_GSW_GSO",
+    "group": "GSW",
     "expression": "([pixel] >= 50 and [pixel] < 51)",
     "style": {
       "__type__": "style",
@@ -16,7 +16,7 @@
   {
     "__type__": "class",
     "name": "50 — 100",
-    "group": "GSC_GSW_GSO",
+    "group": "GSW",
     "expression": "([pixel] >= 51 AND [pixel] < 100)",
     "style": {
       "__type__": "style",
@@ -30,7 +30,7 @@
   {
     "__type__": "class",
     "name": "100 — 150",
-    "group": "GSC_GSW_GSO",
+    "group": "GSW",
     "expression": "([pixel] >= 100 AND [pixel] <= 150 )",
     "style": {
       "__type__": "style",
@@ -44,7 +44,7 @@
   {
     "__type__": "class",
     "name": "150 — 200",
-    "group": "GSC_GSW_GSO",
+    "group": "GSW",
     "expression": "([pixel] >= 150 AND [pixel] < 200)",
     "style": {
       "__type__": "style",
@@ -58,7 +58,7 @@
   {
     "__type__": "class",
     "name": "200 — 250",
-    "group": "GSC_GSW_GSO",
+    "group": "GSW",
     "expression": "([pixel] >= 200 AND [pixel] < 250)",
     "style": {
       "__type__": "style",
@@ -72,7 +72,7 @@
   {
     "__type__": "class",
     "name": "250 — 300",
-    "group": "GSC_GSW_GSO",
+    "group": "GSW",
     "expression": "([pixel] >= 250 AND [pixel] < 300)",
     "style": {
       "__type__": "style",
@@ -86,7 +86,7 @@
   {
     "__type__": "class",
     "name": "300 — 350",
-    "group": "GSC_GSW_GSO",
+    "group": "GSW",
     "expression": "([pixel] >= 300 AND [pixel] < 350)",
     "style": {
       "__type__": "style",
@@ -100,7 +100,7 @@
   {
     "__type__": "class",
     "name": ">= 350",
-    "group": "GSC_GSW_GSO",
+    "group": "GSW",
     "expression": "([pixel] >= 350)",
     "style": {
       "__type__": "style",


### PR DESCRIPTION
I created 3 JSONs for Indices' legends to solve the legend name error. 

The error was that the indices legend names for overwintering crops, cool season crops and warm season crops was always the same (they all had the overwintering one). By splitting the already existing JSON in three distinct JSONs, the problem was solved.

Please note that the colors were not changed as requested.