### PR TITLE
ensure proj_lib key not removed when OWS_LOG is set

### DIFF
--- a/geomet_climate/mapfile.py
+++ b/geomet_climate/mapfile.py
@@ -412,9 +412,7 @@ def generate(ctx, service, layer):
             mapfile['symbols'] = json.load(fh2)
 
     if OWS_LOG is not None:
-        mapfile['config'] = {
-            'ms_errorfile': OWS_LOG
-        }
+        mapfile['config']['ms_errorfile']: OWS_LOG
 
     if OWS_DEBUG is not None:
         mapfile['debug'] = int(OWS_DEBUG)


### PR DESCRIPTION
This MR ensures that the base mapfile's config keys do not get overwritten when the `GEOMET_CLIMATE_OWS_LOG` environment variable is set.


CC @RousseauLambertLP 