### PR TITLE
Dockerize a nightly build for Ubuntu focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:focal
+
+# Allow for change during docker build-time
+ARG GEOMET_CLIMATE_URL=https://geomet-dev-11-nightly.cmc.ec.gc.ca/geomet-climate
+
+ENV BASEDIR=/data/web/geomet-climate-nightly \
+    DOCKERDIR=/data/web/geomet-climate-nightly/docker \
+    GEOMET_CLIMATE_BASEDIR=/data/web/geomet-climate-nightly/build \
+    GEOMET_CLIMATE_DATADIR=/data/geomet/feeds/dd.ops/climate \
+    GEOMET_CLIMATE_CONFIG=/data/web/geomet-climate-nightly/geomet-climate.yml \
+    GEOMET_CLIMATE_URL=${GEOMET_CLIMATE_URL} \
+    GEOMET_CLIMATE_OWS_DEBUG=5
+    # GEOMET_CLIMATE_OWS_LOG=/tmp/geomet-climate-ows.log
+
+WORKDIR $BASEDIR
+
+# Install system dependencies
+RUN apt update && apt install -y software-properties-common && \
+    ## Add this WMO PPA
+    add-apt-repository ppa:gcpp-kalxas/wmo && apt update && \
+    ## Install dependencies from debian/control
+    apt install -y mapserver-bin python3-all python3-pip python3-click python3-gdal python3-mappyfile python3-mapscript python3-matplotlib python3-numpy python3-pyproj python3-yaml proj-bin proj-data && \
+    # remove transient packages
+    apt clean autoclean && apt autoremove --yes && rm -fr /var/lib/{apt,dpkg,cache,log}/
+
+# Copy source code to base directory of container
+COPY . $BASEDIR
+
+# Install application dependencies
+RUN pip3 install -r requirements.txt && \
+    pip3 install -r requirements-dev.txt && \
+    pip3 install -e . && \
+    # add gunicorn for Docker deploy
+    pip3 install gunicorn && \
+    # Getting entrypoint to work
+    touch $DOCKERDIR/entrypoint.sh && chmod 0755 $DOCKERDIR/entrypoint.sh
+
+# Start MSC GeoMet Climate
+ENTRYPOINT [ "sh", "-c", "$DOCKERDIR/entrypoint.sh" ]

--- a/deploy/nightly-docker/deploy-nightly-docker.sh
+++ b/deploy/nightly-docker/deploy-nightly-docker.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# =================================================================
+#
+# Copyright (c) 2020 Government of Canada
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# =================================================================
+
+BASEDIR=/data/web/geomet-climate-nightly
+GEOMET_CLIMATE_GITREPO=https://github.com/ECCC-CCCS/geomet-climate.git
+DAYSTOKEEP=7
+
+# you should be okay from here
+
+DATETIME=`date +%Y%m%d`
+TIMESTAMP=`date +%Y%m%d.%H%M`
+NIGHTLYDIR=geomet-climate-$TIMESTAMP
+
+echo "Deleting nightly builds > $DAYSTOKEEP days old"
+
+cd $BASEDIR
+
+for f in `find . -type d -name "geomet-climate-20*"`
+do
+    DATETIME2=`echo $f | awk -F- '{print $3}' | awk -F. '{print $1}'`
+    let DIFF=(`date +%s -d $DATETIME`-`date +%s -d $DATETIME2`)/86400
+    if [ $DIFF -gt $DAYSTOKEEP ]; then
+        rm -fr $f
+    fi
+done
+
+rm -fr latest
+echo "Generating nightly build for $TIMESTAMP"
+mkdir $NIGHTLYDIR && cd $NIGHTLYDIR
+git clone $GEOMET_CLIMATE_GITREPO . -b master --depth=1
+# git clone https://github.com/kngai/geomet-climate.git . -b docker-nightly --depth=1
+
+echo "Stopping/building/starting Docker setup"
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml down
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml build
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d
+
+cat > geomet-climate-nightly.conf <<EOF
+<Location /geomet-climate>
+  ProxyPass http://localhost:8099/
+  ProxyPassReverse http://localhost:8099/
+  Require all granted
+</Location>
+EOF
+
+cd ..
+
+ln -s $NIGHTLYDIR latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,13 @@
+# Docker setup
+
+```bash
+# build Docker image
+docker build -t eccc-msc/geomet-climate:nightly .
+# (recommended) build Docker image via docker compose
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml build
+# startup MSC GeoMet Climate
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d
+
+# test WMS endpoint
+curl "http://geomet-dev-11.cmc.ec.gc.ca:8099/?service=WMS&version=1.3.0&request=GetCapabilities"
+```

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -1,0 +1,11 @@
+services:
+  geomet-climate-nightly:
+    build:
+      args:
+        GEOMET_CLIMATE_URL: https://geomet-dev-11-nightly.cmc.ec.gc.ca/geomet-climate
+        # GEOMET_CLIMATE_URL: http://geomet-dev-11.cmc.ec.gc.ca:8099
+    environment:
+      GEOMET_CLIMATE_OWS_DEBUG: 5
+      GEOMET_CLIMATE_ES_URL: http://host.docker.internal:9200
+    ports:
+      - "8099:80"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  geomet-climate-nightly:
+    image: eccc-msc/geomet-climate:nightly
+    container_name: geomet-climate-nightly
+    build: 
+      context: ..
+    hostname: geomet-dev-11-docker.cmc.ec.gc.ca
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - "/data/geomet/feeds/dd.ops/climate:/data/geomet/feeds/dd.ops/climate:ro"
+networks:
+  default:
+    name: geomet_default
+    driver: bridge

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# default env variables
+BASEDIR=/data/web/geomet-climate-nightly
+GEOMET_CLIMATE_BASEDIR=$BASEDIR/build
+GEOMET_CLIMATE_ES_URL=${GEOMET_CLIMATE_ES_URL}
+
+# replace localhost ES URL with docker-host URL to ES
+if [ $GEOMET_CLIMATE_ES_URL != "" ]
+then
+    sed -i 's|http://localhost:9200|'$GEOMET_CLIMATE_ES_URL'|g' geomet-climate.yml
+    sed -i 's|http://localhost:9200|'$GEOMET_CLIMATE_ES_URL'|g' tests/geomet-climate-test.yml
+fi
+
+cd $BASEDIR
+
+echo "Generating geomet-climate VRTs for all layers..."
+geomet-climate vrt generate
+echo "Generating geomet-climate tileindex for all layers..."
+geomet-climate tileindex generate
+echo "Generating geomet-climate legends for all layers..."
+geomet-climate legend generate
+echo "Generating geomet-climate mapfile for WMS..."
+geomet-climate mapfile generate -s WMS
+echo "Generating geomet-climate mapfile for WCS..."
+geomet-climate mapfile generate -s WCS
+
+echo "Caching WMS (English)..."
+mapserv -nh QUERY_STRING="map=$GEOMET_CLIMATE_BASEDIR/mapfile/geomet-climate-WMS-en.map&service=WMS&version=1.3.0&request=GetCapabilities" > $GEOMET_CLIMATE_BASEDIR/geomet-climate-WMS-1.3.0-capabilities-en.xml && mv -f $GEOMET_CLIMATE_BASEDIR/geomet-climate-WMS-1.3.0-capabilities-en.xml $GEOMET_CLIMATE_BASEDIR/mapfile
+
+echo "Caching WMS (French)..."
+mapserv -nh QUERY_STRING="map=$GEOMET_CLIMATE_BASEDIR/mapfile/geomet-climate-WMS-fr.map&lang=fr&service=WMS&version=1.3.0&request=GetCapabilities" > $GEOMET_CLIMATE_BASEDIR/geomet-climate-WMS-1.3.0-capabilities-fr.xml && mv -f $GEOMET_CLIMATE_BASEDIR/geomet-climate-WMS-1.3.0-capabilities-fr.xml $GEOMET_CLIMATE_BASEDIR/mapfile
+
+echo "Caching WCS (English)..."
+mapserv -nh QUERY_STRING="map=$GEOMET_CLIMATE_BASEDIR/mapfile/geomet-climate-WCS-en.map&service=WCS&version=2.1.0&request=GetCapabilities" > $GEOMET_CLIMATE_BASEDIR/geomet-climate-WCS-2.0.1-capabilities-en.xml && mv -f $GEOMET_CLIMATE_BASEDIR/geomet-climate-WCS-2.0.1-capabilities-en.xml $GEOMET_CLIMATE_BASEDIR/mapfile
+
+echo "Caching WCS (French)..."
+mapserv -nh QUERY_STRING="map=$GEOMET_CLIMATE_BASEDIR/mapfile/geomet-climate-WCS-fr.map&lang=fr&service=WCS&version=2.1.0&request=GetCapabilities" > $GEOMET_CLIMATE_BASEDIR/geomet-climate-WCS-2.0.1-capabilities-fr.xml && mv -f $GEOMET_CLIMATE_BASEDIR/geomet-climate-WCS-2.0.1-capabilities-fr.xml $GEOMET_CLIMATE_BASEDIR/mapfile
+
+echo "Done."
+
+# server runs
+echo "Starting up geomet-climate via gunicorn..."
+# geomet-climate serve --port=80
+gunicorn -w 2 -b 0.0.0.0:80 --chdir $BASEDIR/geomet_climate wsgi:application --reload --timeout 900 --access-logfile /tmp/gunicorn-geomet-climate.log


### PR DESCRIPTION
- Reorder Dockerfile commands for optimizing build times
- Use gunicorn to start up geomet-climate in entrypoint.sh
- Add sh script for cron deployment of nightly docker
- Replace localhost:9200 with host.docker.internal:9200 for ES connections in .yml file
- Set default network name and container name