### PR TITLE
Change port declaration to port 8099 with while using network_mode: host

### DIFF
--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -8,4 +8,4 @@ services:
       GEOMET_CLIMATE_OWS_DEBUG: 5
       GEOMET_CLIMATE_ES_URL: http://localhost:9200
     ports:
-      - "8099:80"
+      - "8099:8099"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -41,4 +41,4 @@ echo "Done."
 # server runs
 echo "Starting up geomet-climate via gunicorn..."
 # geomet-climate serve --port=80
-gunicorn -w 2 -b 0.0.0.0:80 --chdir $BASEDIR/geomet_climate wsgi:application --reload --timeout 900 --access-logfile /tmp/gunicorn-geomet-climate.log
+gunicorn -w 2 -b 0.0.0.0:8099 --chdir $BASEDIR/geomet_climate wsgi:application --reload --timeout 900 --access-logfile /tmp/gunicorn-geomet-climate.log


### PR DESCRIPTION
Nightly docker run fails due to using port 80 but no longer using the container's network (after we changed to use docker `network_mode: host`). This conflicts with the default port 80 on the host machine.

Fix by changing `gunicorn` to run on port 8099 of the host.