### PR TITLE
BUGFIX: update for ES needing credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ ENV BASEDIR=/data/web/geomet-climate-nightly \
     GEOMET_CLIMATE_DATADIR=/data/geomet/feeds/dd/climate \
     GEOMET_CLIMATE_CONFIG=/data/web/geomet-climate-nightly/geomet-climate.yml \
     GEOMET_CLIMATE_URL=${GEOMET_CLIMATE_URL} \
+    # GEOMET_CLIMATE_ES_USERNAME=foo
+    # GEOMET_CLIMATE_ES_PASSWORD=bar
+    # ES credentials loaded from host env
+    GEOMET_CLIMATE_ES_URL=https://${GEOMET_CLIMATE_ES_USERNAME}:${GEOMET_CLIMATE_ES_PASSWORD}@localhost:9200 \
     GEOMET_CLIMATE_OWS_DEBUG=5
     # GEOMET_CLIMATE_OWS_LOG=/tmp/geomet-climate-ows.log
 

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -6,6 +6,6 @@ services:
         # GEOMET_CLIMATE_URL: http://geomet-dev-11.cmc.ec.gc.ca:8099
     environment:
       GEOMET_CLIMATE_OWS_DEBUG: 5
-      GEOMET_CLIMATE_ES_URL: http://localhost:9200
+      GEOMET_CLIMATE_ES_URL: http://${GEOMET_CLIMATE_ES_USERNAME}:${GEOMET_CLIMATE_ES_PASSWORD}@localhost:9200
     ports:
       - "8099:8099"

--- a/geomet-climate.env
+++ b/geomet-climate.env
@@ -4,3 +4,7 @@ export GEOMET_CLIMATE_CONFIG=`pwd`/geomet-climate.yml
 export GEOMET_CLIMATE_URL=https://geo.weather.gc.ca/geomet-climate
 #export GEOMET_CLIMATE_OWS_DEBUG=5
 #export GEOMET_CLIMATE_OWS_LOG=/tmp/geomet-climate-ows.log
+
+#export GEOMET_CLIMATE_ES_USERNAME=foo
+#export GEOMET_CLIMATE_ES_PASSWORD=bar
+export GEOMET_CLIMATE_ES_URL=http://${GEOMET_CLIMATE_ES_USERNAME}:${GEOMET_CLIMATE_ES_PASSWORD}@localhost:9200

--- a/geomet_climate/env.py
+++ b/geomet_climate/env.py
@@ -31,6 +31,7 @@ DATADIR = os.environ.get('GEOMET_CLIMATE_DATADIR', None)
 OWS_DEBUG = os.environ.get('GEOMET_CLIMATE_OWS_DEBUG', None)
 OWS_LOG = os.environ.get('GEOMET_CLIMATE_OWS_LOG', None)
 URL = os.environ.get('GEOMET_CLIMATE_URL', None)
+ES_URL = os.getenv('GEOMET_CLIMATE_ES_URL', None)
 
 LOGGER.debug(BASEDIR)
 LOGGER.debug(CONFIG)

--- a/geomet_climate/mapfile.py
+++ b/geomet_climate/mapfile.py
@@ -34,7 +34,7 @@ from yaml import CLoader
 
 from geomet_climate import __version__
 from geomet_climate.env import (
-    BASEDIR, CONFIG, DATADIR, OWS_DEBUG, OWS_LOG, URL)
+    BASEDIR, CONFIG, DATADIR, OWS_DEBUG, OWS_LOG, URL, ES_URL)
 
 MAPFILE_BASE = '{}{}resources{}mapfile-base.json'.format(os.path.dirname(
     os.path.realpath(__file__)), os.sep, os.sep)
@@ -248,8 +248,7 @@ def gen_layer(layer_name, layer_info,  template_path, service='WMS'):
     if layer_info['type'] == 'POINT':
         layer['type'] = layer_info['type']
         layer['connectiontype'] = 'OGR'
-        layer['connection'] = 'ES:{}'.format(
-            layer_info['climate_model']['basepath'])
+        layer['connection'] = 'ES:{}'.format(ES_URL)
 
         layer['connectionoptions'] = {
             '__type__': 'connectionoptions',


### PR DESCRIPTION
Given we are now using ES 8, we need to pass the credentials to connect to ESS for the climate, AHCCD and hydrometric stations.

The credentials were also added in the geomet-nightly profile and this merge request was tested on docker and works properly.

This is a bugfix and should be backported. 

cc @Dukestep 