### PR TITLE
Reorder docker nightly build steps with no-cache

### DIFF
--- a/deploy/nightly-docker/deploy-nightly-docker.sh
+++ b/deploy/nightly-docker/deploy-nightly-docker.sh
@@ -48,8 +48,8 @@ git clone $GEOMET_CLIMATE_GITREPO . -b master --depth=1
 # git clone https://github.com/kngai/geomet-climate.git . -b docker-nightly --depth=1
 
 echo "Stopping/building/starting Docker setup"
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml build --no-cache
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml down
-docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml build
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d
 
 cat > geomet-climate-nightly.conf <<EOF


### PR DESCRIPTION
This PR simply reorders the docker nightly build steps with no-cache, so the image can be built before bringing the container down.