### PR TITLE
Set docker-compose project name to "geomet-climate-nightly" instead of "docker" 

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=geomet-climate-nightly


### PR DESCRIPTION
This PR addresses a minor docker issue on nightly, where project name defaults to the current directory name where `docker-compose.yml` is. In this case, the name becomes `docker`. With many of our other nightly deploys using the same `/docker` folder structure, this leads to a lot of false warnings about the orphaned container named "docker" still existing during a `docker compose up/down`.

Adding `/docker/.env` with `COMPOSE_PROJECT_NAME=name-of-your-application` avoids this.