### PR TITLE
ensure debian conffiles uses absolute pathing

### DIFF
--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,2 +1,2 @@
-opt/geomet-climate/app/geomet-climate.wsgi
-opt/geomet-climate/etc/amqp-climate.dd.conf
+/opt/geomet-climate/app/geomet-climate.wsgi
+/opt/geomet-climate/etc/amqp-climate.dd.conf


### PR DESCRIPTION
As per the  [Automatic handling of configuration files by dpkg](https://www.debian.org/doc/debian-policy/ap-pkg-conffiles.html#automatic-handling-of-configuration-files-by-dpkg) section of the Debian Policy Manual, the `conffiles` entries must contain filenames with absolute pathnames. This was causing an issue when installing the package on upcoming jammy environments.

This PR ensures filenames in `conffiles` have absolute paths.