### PR TITLE
Docker changes for dev-31 and MapServer 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,18 @@ ENV BASEDIR=/data/web/geomet-climate-nightly \
     # GEOMET_CLIMATE_ES_PASSWORD=bar
     # ES credentials loaded from host env
     GEOMET_CLIMATE_ES_URL=https://${GEOMET_CLIMATE_ES_USERNAME}:${GEOMET_CLIMATE_ES_PASSWORD}@localhost:9200 \
-    GEOMET_CLIMATE_OWS_DEBUG=5 \
-    MAPSERVER_CONFIG_FILE=${GEOMET_CLIMATE_BASEDIR}/mapserver.conf
+    GEOMET_CLIMATE_OWS_DEBUG=5
     # GEOMET_CLIMATE_OWS_LOG=/tmp/geomet-climate-ows.log
+ENV DEBIAN_FRONTEND=noninteractive
+ENV MAPSERVER_CONFIG_FILE=${GEOMET_CLIMATE_BASEDIR}/mapserver.conf
 
 WORKDIR $BASEDIR
 
 # Install system dependencies
 RUN apt update && apt install -y software-properties-common && \
-    ## Add this WMO PPA
+    ## Add this UbuntuGIS PPA (mappyfile)
+    add-apt-repository ppa:ubuntugis/ppa && apt update && \
+    ## Add this WMO PPA (mapserver)
     add-apt-repository ppa:gcpp-kalxas/wmo-staging && apt update && \
     ## Install dependencies from debian/control
     apt install -y mapserver-bin python3-all python3-pip python3-click python3-gdal python3-mappyfile python3-mapscript python3-matplotlib python3-numpy python3-pyproj python3-yaml proj-bin proj-data python3-certifi && \

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -3,7 +3,6 @@ services:
     build:
       args:
         GEOMET_CLIMATE_URL: https://geomet-dev-31-nightly.edc-mtl.ec.gc.ca/geomet-climate
-        # GEOMET_CLIMATE_URL: http://geomet-dev-31.edc-mtl.ec.gc.ca:8099
     environment:
       GEOMET_CLIMATE_OWS_DEBUG: 5
       GEOMET_CLIMATE_ES_URL: http://${GEOMET_CLIMATE_ES_USERNAME}:${GEOMET_CLIMATE_ES_PASSWORD}@localhost:9200

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       # for SSL-enabled connections to internal hosts (geomet-dev-xx.edc-mtl.ec.gc.ca)
       - "/etc/ssl/certs:/etc/ssl/certs:ro" # mount host ssl certs
       - "/usr/local/share/ca-certificates/:/usr/local/share/ca-certificates/:ro" # mount host ca-certificates
-
 networks:
   default:
     name: geomet_default

--- a/geomet-climate.env
+++ b/geomet-climate.env
@@ -8,3 +8,4 @@ export GEOMET_CLIMATE_URL=https://geo.weather.gc.ca/geomet-climate
 #export GEOMET_CLIMATE_ES_USERNAME=foo
 #export GEOMET_CLIMATE_ES_PASSWORD=bar
 export GEOMET_CLIMATE_ES_URL=http://${GEOMET_CLIMATE_ES_USERNAME}:${GEOMET_CLIMATE_ES_PASSWORD}@localhost:9200
+export MAPSERVER_CONFIG_FILE=${GEOMET_CLIMATE_BASEDIR}/mapserver.conf

--- a/tests/geomet-climate-test.env
+++ b/tests/geomet-climate-test.env
@@ -2,3 +2,4 @@ export GEOMET_CLIMATE_BASEDIR=.
 export GEOMET_CLIMATE_DATADIR=tests/data/climate
 export GEOMET_CLIMATE_CONFIG=./tests/geomet-climate-test.yml
 export GEOMET_CLIMATE_URL=http://localhost:8099
+export MAPSERVER_CONFIG_FILE=${GEOMET_CLIMATE_BASEDIR}/mapserver.conf


### PR DESCRIPTION
This PR updates the codebase to work with MapServer 8, `dev-31` URLs, `ubuntu:jammy`, and Docker:
- Testing with wmo-staging PPA
- Check to ensure required ENVs are set
- Add SSL ceritficate volume mounts for dev-31
- ~~Includes 1 commit from `master` branch (https://github.com/ECCC-CCCS/geomet-climate/commit/35dfac62afb42945f42aaed931ca25ae3f094ad0) that was meant for `jammy` branch~~