### PR TITLE
add MapServer configuration file for MapServer 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ ENV BASEDIR=/data/web/geomet-climate-nightly \
     # GEOMET_CLIMATE_ES_PASSWORD=bar
     # ES credentials loaded from host env
     GEOMET_CLIMATE_ES_URL=https://${GEOMET_CLIMATE_ES_USERNAME}:${GEOMET_CLIMATE_ES_PASSWORD}@localhost:9200 \
-    GEOMET_CLIMATE_OWS_DEBUG=5
+    GEOMET_CLIMATE_OWS_DEBUG=5 \
+    MAPSERVER_CONFIG_FILE=${GEOMET_CLIMATE_BASEDIR}/mapserver.conf
     # GEOMET_CLIMATE_OWS_LOG=/tmp/geomet-climate-ows.log
 
 WORKDIR $BASEDIR

--- a/geomet_climate/mapfile.py
+++ b/geomet_climate/mapfile.py
@@ -43,6 +43,13 @@ LOGGER = logging.getLogger(__name__)
 
 THISDIR = os.path.dirname(os.path.realpath(__file__))
 
+MAPSERVER_CONFIG = f'''CONFIG
+    ENV
+        MS_MAP_PATTERN "{BASEDIR}/mapfile/.*"
+    END
+END
+'''
+
 
 def gen_web_metadata(m, c, service, url):
     """
@@ -395,6 +402,14 @@ def mapfile():
 @click.option('--layer', '-lyr', help='layer')
 def generate(ctx, service, layer):
     """generate mapfile"""
+
+    # generate MapServer config file if not present
+    mapserver_config_file = os.path.join(BASEDIR, 'mapserver.conf')
+
+    if not os.path.exists(mapserver_config_file):
+        os.makedirs(BASEDIR, exist_ok=True)
+        with open(mapserver_config_file, 'w+') as f:
+            f.write(MAPSERVER_CONFIG)
 
     output_dir = '{}{}mapfile'.format(BASEDIR, os.sep)
     template_dir = '{}{}mapfile{}template'.format(BASEDIR, os.sep, os.sep)


### PR DESCRIPTION
This PR adds the generation of the `mapserver.conf` file via the `geomet-climate mapfile generate` comman. The `MS_MAP_PATTERN` path uses the `GEOMET_CLIMATE_BASEDIR` environment variable to determine the file's filepath.

I've also updated the Dockerfile to add a `MAPSERVER_CONFIG_FILE` environment variable.