### PR TITLE
Update Dockerfile for nightly and update debian/rules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ ENV BASEDIR=/data/web/geomet-climate-nightly \
     GEOMET_CLIMATE_URL=${GEOMET_CLIMATE_URL} \
     # GEOMET_CLIMATE_ES_USERNAME=foo
     # GEOMET_CLIMATE_ES_PASSWORD=bar
-    # ES credentials loaded from host env
-    GEOMET_CLIMATE_ES_URL=https://${GEOMET_CLIMATE_ES_USERNAME}:${GEOMET_CLIMATE_ES_PASSWORD}@localhost:9200 \
+    # ES credentials and GEOMET_CLIMATE_ES_URL loaded from host env
+    GEOMET_CLIMATE_ES_URL=https://username:password@localhost:9200 \
     GEOMET_CLIMATE_OWS_DEBUG=5
     # GEOMET_CLIMATE_OWS_LOG=/tmp/geomet-climate-ows.log
 ENV DEBIAN_FRONTEND=noninteractive
@@ -25,7 +25,7 @@ RUN apt update && apt install -y software-properties-common && \
     ## Add this UbuntuGIS PPA (mappyfile)
     add-apt-repository ppa:ubuntugis/ppa && apt update && \
     ## Add this WMO PPA (mapserver)
-    add-apt-repository ppa:gcpp-kalxas/wmo-staging && apt update && \
+    add-apt-repository ppa:gcpp-kalxas/wmo && apt update && \
     ## Install dependencies from debian/control
     apt install -y mapserver-bin python3-all python3-pip python3-click python3-gdal python3-mappyfile python3-mapscript python3-matplotlib python3-numpy python3-pyproj python3-yaml proj-bin proj-data python3-certifi && \
     # remove transient packages

--- a/debian/rules
+++ b/debian/rules
@@ -14,3 +14,9 @@
 
 override_dh_auto_test:
 	@echo "nocheck set, not running tests"
+
+# clean up the test data files
+override_dh_clean:
+	dh_clean
+	find tests/data -name '*.tif' -delete
+	find tests/data -name '*.nc' -delete

--- a/deploy/nightly-docker/deploy-nightly-docker.sh
+++ b/deploy/nightly-docker/deploy-nightly-docker.sh
@@ -59,7 +59,7 @@ mkdir $NIGHTLYDIR && cd $NIGHTLYDIR
 git clone $GEOMET_CLIMATE_GITREPO . -b master --depth=1
 
 echo "Stopping/building/starting Docker setup"
-docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml build --no-cache
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml build --no-cache | tee docker-build.log
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml down
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.override.yml up -d
 


### PR DESCRIPTION
Dockerfile updates and debian updates affecting build:
- Update Dockerfile to use wmo PPA and set GEOMET_CLIMATE_ES_URL as a template value to be overritten by docker-compose.override.yml
- Update debian/rules to clean out tests/data *.tif and *.nc
- Add pipe to output a nightly docker build log for future debugging purposes