### PR TITLE
ensure GetMap transparent by default and GetLegendGraphic is not

### DIFF
--- a/geomet_climate/resources/mapfile-base.json
+++ b/geomet_climate/resources/mapfile-base.json
@@ -14,6 +14,15 @@
     "projection": ["init=epsg:4326"],
     "outputformats": [{
         "__type__": "outputformat",
+        "name": "PNG",
+        "driver": "AAG/PNG",
+        "mimetype": "image/png",
+        "imagemode": "RGB",
+        "extension": "png",
+        "formatoption": ["GAMMA=0.75"],
+        "transparent": true
+    },{
+        "__type__": "outputformat",
         "name": "GEOTIFF_32",
         "driver": "GDAL/GTiff",
         "mimetype": "image/tiff",
@@ -45,7 +54,8 @@
             "__type__": "label",
             "size": 10,
             "color": [0, 0, 0]
-        }
+        },
+        "transparent": false
     },
     "web": {
         "__type__": "web",


### PR DESCRIPTION
This PR ensures that WMS GetMap requests in PNG format are transparent by default while also ensuring WMS GetLegendGraphic are not transparent by default. This restores the expected behaviour prior to the release of GeoMet Climate `1.14.0`.