### PR TITLE
fix typo in PNG outputformat driver name

### DIFF
--- a/geomet_climate/resources/mapfile-base.json
+++ b/geomet_climate/resources/mapfile-base.json
@@ -15,7 +15,7 @@
     "outputformats": [{
         "__type__": "outputformat",
         "name": "PNG",
-        "driver": "AAG/PNG",
+        "driver": "AGG/PNG",
         "mimetype": "image/png",
         "imagemode": "RGB",
         "extension": "png",


### PR DESCRIPTION
This PR fixes a small typo in the PNG `OUTPUTFORMAT.DRIVER` directive.