### PR TITLE
Adjust legends.py for GeoMet-Climate

### DIFF
--- a/geomet_climate/legend.py
+++ b/geomet_climate/legend.py
@@ -21,6 +21,7 @@ import io
 import json
 import logging
 import os
+import re
 
 import click
 import matplotlib as mpl
@@ -34,6 +35,8 @@ from geomet_climate.env import BASEDIR, CONFIG
 LOGGER = logging.getLogger(__name__)
 
 THISDIR = os.path.dirname(os.path.realpath(__file__))
+
+NUMERIC_VALUE_RE = r'[-+]?\d*\.?\d+([eE][-+]?\d+)?|[-+]?\d+([eE][-+]?\d+)?'
 
 
 def generate_legend(layer_info, output_dir):
@@ -77,15 +80,39 @@ def generate_legend(layer_info, output_dir):
                 color_arr.append(color)
 
         if linear:
-            min_value = style_json[0]['name'].split(' ')[0]
+            discrete = False
+            # if starts with a symbol, get lower bound from next class
+            if re.search(r'-?\d+\.?\d*', style_json[0]['name'].split(' ')[0]):
+                min_value = style_json[0]['name'].split(' ')[0]
+            else:
+                min_value = style_json[1]['name'].split(' ')[0]
+
             max_value = style_json[-1]['name'].split(' ')[-1]
+            max_value_first_part = style_json[-1]['name'].split(' ')[0]
+            min_value_first_part = style_json[0]['name'].split(' ')[0]
+            min_value_number_part = re.search(NUMERIC_VALUE_RE, min_value)
+            max_value_numer_part = re.search(NUMERIC_VALUE_RE, max_value)
+
+            if min_value_number_part:
+                min_value = min_value_number_part.group()
+            else:
+                if len(style_json[0]['name'].split(' ')) >= 2:
+                    min_value = style_json[0]['name'].split(' ')[1]
+
+            if max_value_numer_part:
+                max_value = max_value_numer_part.group()
+            else:
+                max_value = style_json[-1]['name'].split(' ')[-2]
 
             fig = Figure(figsize=(1, 5))
             # when moving to ubuntu 18.04 and remove add_subplots
             # ax = fig.subplots()
             ax = fig.add_subplot(121)
 
-            all_vals = np.array([[0, 0, 0, 1]])
+            all_vals = np.array([[color_arr[0][0] / 256.0,
+                                color_arr[0][1] / 256.0,
+                                color_arr[0][2] / 256.0,
+                                1]])
 
             for i in range(0, len(color_arr) - 1):
                 # number of interpolated values between 2 color ramps
@@ -109,7 +136,21 @@ def generate_legend(layer_info, output_dir):
             newcmp = mpl.colors.ListedColormap(all_vals)
             norm = mpl.colors.Normalize(vmin=float(min_value),
                                         vmax=float(max_value))
-            cb = mpl.colorbar.ColorbarBase(ax, cmap=newcmp, norm=norm)
+            # Arrow cap only on the ends that are open-ended.
+            min_open = min_value_first_part in ['<', '<=']
+            max_open = max_value_first_part in ['>', '>=']
+            if min_open and max_open:
+                extend = 'both'
+            elif max_open:
+                extend = 'max'
+            elif min_open:
+                extend = 'min'
+            else:
+                extend = 'neither'
+
+            cb = mpl.colorbar.ColorbarBase(
+                ax, cmap=newcmp, norm=norm, extend=extend
+            )
 
         if discrete:
             bounds = layer_info['bounds']
@@ -132,14 +173,33 @@ def generate_legend(layer_info, output_dir):
                         1]]
                 all_vals = np.concatenate((all_vals, vals))
 
-            cmap = mpl.colors.ListedColormap(all_vals[1:-1])
-            cmap.set_over(all_vals[-1])
-            cmap.set_under(all_vals[0])
+            # Reserve an arrow-cap color only on ends that are open-ended.
+            min_value_first_part = style_json[0]['name'].split(' ')[0]
+            max_value_first_part = style_json[-1]['name'].split(' ')[0]
+            min_open = min_value_first_part in ['<', '<=']
+            max_open = max_value_first_part in ['>', '>=']
+
+            if min_open and max_open:
+                cmap = mpl.colors.ListedColormap(all_vals[1:-1])
+                cmap.set_under(all_vals[0])
+                cmap.set_over(all_vals[-1])
+                extend = 'both'
+            elif max_open:
+                cmap = mpl.colors.ListedColormap(all_vals[:-1])
+                cmap.set_over(all_vals[-1])
+                extend = 'max'
+            elif min_open:
+                cmap = mpl.colors.ListedColormap(all_vals[1:])
+                cmap.set_under(all_vals[0])
+                extend = 'min'
+            else:
+                cmap = mpl.colors.ListedColormap(all_vals)
+                extend = 'neither'
 
             norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
             cb = mpl.colorbar.ColorbarBase(ax, cmap=cmap,
                                            norm=norm,
-                                           extend='both',
+                                           extend=extend,
                                            extendfrac='auto',
                                            ticks=bounds,
                                            spacing='uniform')

--- a/geomet_climate/resources/mapserv/class/gsc.json
+++ b/geomet_climate/resources/mapserv/class/gsc.json
@@ -1,9 +1,9 @@
 [
   {
     "__type__": "class",
-    "name": "50",
+    "name": "< 50",
     "group": "GSC",
-    "expression": "([pixel] >= 50 and [pixel] < 51)",
+    "expression": "([pixel] < 50",
     "style": {
       "__type__": "style",
       "color": [
@@ -17,7 +17,7 @@
     "__type__": "class",
     "name": "50 — 100",
     "group": "GSC",
-    "expression": "([pixel] >= 51 AND [pixel] < 100)",
+    "expression": "([pixel] >= 50 AND [pixel] < 100)",
     "style": {
       "__type__": "style",
       "color": [
@@ -31,7 +31,7 @@
     "__type__": "class",
     "name": "100 — 150",
     "group": "GSC",
-    "expression": "([pixel] >= 100 AND [pixel] <= 150 )",
+    "expression": "([pixel] >= 100 AND [pixel] < 150 )",
     "style": {
       "__type__": "style",
       "color": [

--- a/geomet_climate/resources/mapserv/class/gso.json
+++ b/geomet_climate/resources/mapserv/class/gso.json
@@ -1,9 +1,9 @@
 [
   {
     "__type__": "class",
-    "name": "50",
+    "name": "< 50",
     "group": "GSO",
-    "expression": "([pixel] >= 50 and [pixel] < 51)",
+    "expression": "([pixel] < 50)",
     "style": {
       "__type__": "style",
       "color": [
@@ -17,7 +17,7 @@
     "__type__": "class",
     "name": "50 — 100",
     "group": "GSO",
-    "expression": "([pixel] >= 51 AND [pixel] < 100)",
+    "expression": "([pixel] >= 50 AND [pixel] < 100)",
     "style": {
       "__type__": "style",
       "color": [
@@ -31,7 +31,7 @@
     "__type__": "class",
     "name": "100 — 150",
     "group": "GSO",
-    "expression": "([pixel] >= 100 AND [pixel] <= 150 )",
+    "expression": "([pixel] >= 100 AND [pixel] < 150 )",
     "style": {
       "__type__": "style",
       "color": [

--- a/geomet_climate/resources/mapserv/class/gsw.json
+++ b/geomet_climate/resources/mapserv/class/gsw.json
@@ -1,9 +1,9 @@
 [
   {
     "__type__": "class",
-    "name": "50",
+    "name": "< 50",
     "group": "GSW",
-    "expression": "([pixel] >= 50 and [pixel] < 51)",
+    "expression": "([pixel] < 50)",
     "style": {
       "__type__": "style",
       "color": [
@@ -17,7 +17,7 @@
     "__type__": "class",
     "name": "50 — 100",
     "group": "GSW",
-    "expression": "([pixel] >= 51 AND [pixel] < 100)",
+    "expression": "([pixel] >= 50 AND [pixel] < 100)",
     "style": {
       "__type__": "style",
       "color": [
@@ -31,7 +31,7 @@
     "__type__": "class",
     "name": "100 — 150",
     "group": "GSW",
-    "expression": "([pixel] >= 100 AND [pixel] <= 150 )",
+    "expression": "([pixel] >= 100 AND [pixel] < 150 )",
     "style": {
       "__type__": "style",
       "color": [

--- a/geomet_climate/resources/mapserv/class/hdd.json
+++ b/geomet_climate/resources/mapserv/class/hdd.json
@@ -1,9 +1,9 @@
 [
   {
     "__type__": "class",
-    "name": "<= 2000",
+    "name": "< 2000",
     "group": "HDD",
-    "expression": "([pixel] <= 2000)",
+    "expression": "([pixel] < 2000)",
     "style": {
       "__type__": "style",
       "color": [
@@ -17,7 +17,7 @@
     "__type__": "class",
     "name": "2000 — 4000",
     "group": "HDD",
-    "expression": "([pixel] > 2000 AND [pixel] < 4000)",
+    "expression": "([pixel] >= 2000 AND [pixel] < 4000)",
     "style": {
       "__type__": "style",
       "color": [
@@ -31,7 +31,7 @@
     "__type__": "class",
     "name": "4000 — 6000",
     "group": "HDD",
-    "expression": "([pixel] >= 4000 AND [pixel] < 6000 )",
+    "expression": "([pixel] >= 4000 AND [pixel] < 6000)",
     "style": {
       "__type__": "style",
       "color": [

--- a/geomet_climate/resources/mapserv/class/precip_absolute.json
+++ b/geomet_climate/resources/mapserv/class/precip_absolute.json
@@ -652,7 +652,7 @@
   },
   {
     "__type__": "class",
-    "name": "4650.0 4800.0",
+    "name": ">= 4650.0",
     "group": "PRECIPITATION",
     "expression": "([pixel] >= 4650.0)",
     "style": {

--- a/geomet_climate/resources/mapserv/class/precip_absolute_cmip5.json
+++ b/geomet_climate/resources/mapserv/class/precip_absolute_cmip5.json
@@ -234,7 +234,7 @@
     "__type__": "class",
     "name": "22.0 24.0",
     "group": "PRECIPITATION-CMIP5",
-    "expression": "([pixel] >= 22.0)",
+    "expression": "([pixel] >= 22.0 AND [pixel] <  24.0)",
     "style": {
       "__type__": "style",
       "colorrange": [
@@ -247,6 +247,27 @@
       ],
       "datarange": [
         22.0,
+        24.0
+      ]
+    }
+  },
+{
+    "__type__": "class",
+    "name": ">= 24.0",
+    "group": "PRECIPITATION-CMIP5",
+    "expression": "([pixel] >= 24.0)",
+    "style": {
+      "__type__": "style",
+      "colorrange": [
+        11,
+        58,
+        91,
+        11,
+        58,
+        91
+      ],
+      "datarange": [
+        24.0,
         45.0
       ]
     }

--- a/geomet_climate/resources/mapserv/class/precip_absolute_cmip6.json
+++ b/geomet_climate/resources/mapserv/class/precip_absolute_cmip6.json
@@ -234,7 +234,7 @@
     "__type__": "class",
     "name": "22.0 24.0",
     "group": "PRECIPITATION-CMIP6",
-    "expression": "([pixel] >= 22.0)",
+    "expression": "([pixel] >= 22.0 AND [pixel] <  24.0)",
     "style": {
       "__type__": "style",
       "colorrange": [
@@ -247,6 +247,27 @@
       ],
       "datarange": [
         22.0,
+        24.0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": ">= 24.0",
+    "group": "PRECIPITATION-CMIP6",
+    "expression": "([pixel] >= 24.0)",
+    "style": {
+      "__type__": "style",
+      "colorrange": [
+        11,
+        58,
+        91,
+        11,
+        58,
+        91
+      ],
+      "datarange": [
+        24.0,
         45.0
       ]
     }

--- a/geomet_climate/resources/mapserv/class/prep1.json
+++ b/geomet_climate/resources/mapserv/class/prep1.json
@@ -1,9 +1,9 @@
 [
   {
     "__type__": "class",
-    "name": "<= 10",
+    "name": "< 10",
     "group": "PREP1",
-    "expression": "([pixel] <= 10)",
+    "expression": "([pixel] < 10)",
     "style": {
       "__type__": "style",
       "color": [
@@ -17,7 +17,7 @@
     "__type__": "class",
     "name": "10 — 20",
     "group": "PREP1",
-    "expression": "([pixel] > 10 AND [pixel] < 20)",
+    "expression": "([pixel] >= 10 AND [pixel] < 20)",
     "style": {
       "__type__": "style",
       "color": [

--- a/geomet_climate/resources/mapserv/class/sea-ice-concentration_absolute.json
+++ b/geomet_climate/resources/mapserv/class/sea-ice-concentration_absolute.json
@@ -1,7 +1,7 @@
 [
   {
     "__type__": "class",
-    "name": "-31.5 -28.0",
+    "name": "< -28.0",
     "group": "SEAICECONCENTRATION-ABSOLUTE",
     "expression": "([pixel] <  -28.0)",
     "style": {
@@ -316,7 +316,7 @@
   },
   {
     "__type__": "class",
-    "name": "28.0 31.5",
+    "name": ">= 28.0",
     "group": "SEAICECONCENTRATION-ABSOLUTE",
     "expression": "([pixel] >= 28.0)",
     "style": {

--- a/geomet_climate/resources/mapserv/class/sea-ice-thickness_absolute.json
+++ b/geomet_climate/resources/mapserv/class/sea-ice-thickness_absolute.json
@@ -150,7 +150,7 @@
     "__type__": "class",
     "name": "7.0 8.0",
     "group": "SEAICETHICKNESS-ABSOLUTE",
-    "expression": "([pixel] >= 7.0)",
+    "expression": "([pixel] >= 7.0 AND [pixel] <  8.0)",
     "style": {
       "__type__": "style",
       "colorrange": [
@@ -163,6 +163,27 @@
       ],
       "datarange": [
         7.0,
+        8.0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": ">= 8.0",
+    "group": "SEAICETHICKNESS-ABSOLUTE",
+    "expression": "([pixel] >= 8.0)",
+    "style": {
+      "__type__": "style",
+      "colorrange": [
+        255,
+        32,
+        32,
+        255,
+        32,
+        32
+      ],
+      "datarange": [
+        8.0,
         35.0
       ]
     }

--- a/geomet_climate/resources/mapserv/class/snow-depth_anomaly.json
+++ b/geomet_climate/resources/mapserv/class/snow-depth_anomaly.json
@@ -1,9 +1,30 @@
 [
   {
     "__type__": "class",
+    "name": "< -100",
+    "group": "SNOWDEPTH-ANOMALY",
+    "expression": "([pixel] >= -999 AND [pixel] <  -100)",
+    "style": {
+      "__type__": "style",
+      "colorrange": [
+        103,
+        0,
+        31,
+        103,
+        0,
+        31
+      ],
+      "datarange": [
+        -300,
+        -100
+      ]
+    }
+  },
+  {
+    "__type__": "class",
     "name": "-100 -90",
     "group": "SNOWDEPTH-ANOMALY",
-    "expression": "([pixel] >= -999 AND [pixel] <  -90)",
+    "expression": "([pixel] >= -100 AND [pixel] <  -90)",
     "style": {
       "__type__": "style",
       "colorrange": [
@@ -15,7 +36,7 @@
         37
       ],
       "datarange": [
-        -300,
+        -100,
         -90
       ]
     }
@@ -402,7 +423,7 @@
     "__type__": "class",
     "name": "90 100",
     "group": "SNOWDEPTH-ANOMALY",
-    "expression": "([pixel] >= 90)",
+    "expression": "([pixel] >= 90 AND [pixel] < 100)",
     "style": {
       "__type__": "style",
       "colorrange": [
@@ -415,7 +436,28 @@
       ],
       "datarange": [
         90,
-        250
+        100
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "> 100",
+    "group": "SNOWDEPTH-ANOMALY",
+    "expression": "([pixel] >= 100)",
+    "style": {
+      "__type__": "style",
+      "colorrange": [
+        5,
+        48,
+        97,
+        5,
+        48,
+        97
+      ],
+      "datarange": [
+        100,
+        300
       ]
     }
   }

--- a/geomet_climate/resources/mapserv/class/snow_depth.json
+++ b/geomet_climate/resources/mapserv/class/snow_depth.json
@@ -1,7 +1,7 @@
 [
   {
     "__type__": "class",
-    "name": "-1.5 -1.125",
+    "name": "<  -1.125",
     "group": "SNOWDEPTH-ABSOLUTE",
     "expression": "([pixel] <  -1.125)",
     "style": {
@@ -148,7 +148,7 @@
   },
   {
     "__type__": "class",
-    "name": "1.125 1.5",
+    "name": ">= 1.125",
     "group": "SNOWDEPTH-ABSOLUTE",
     "expression": "([pixel] >= 1.125)",
     "style": {

--- a/geomet_climate/resources/mapserv/class/snow_depth_20years.json
+++ b/geomet_climate/resources/mapserv/class/snow_depth_20years.json
@@ -1,6 +1,27 @@
 [
   {
     "__type__": "class",
+    "name": "< -100.0",
+    "group": "SNOWDEPTH-ANOMALY-AVERAGE",
+    "expression": "([pixel] <  -100.0)",
+    "style": {
+      "__type__": "style",
+      "colorrange": [
+        103,
+        0,
+        31,
+        103,
+        0,
+        31
+      ],
+      "datarange": [
+        -1000.0,
+        -100.0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
     "name": "-100.0 -90.0",
     "group": "SNOWDEPTH-ANOMALY-AVERAGE",
     "expression": "([pixel] <  -90.0)",
@@ -15,7 +36,7 @@
         37
       ],
       "datarange": [
-        -1000.0,
+        -100.0,
         -90.0
       ]
     }
@@ -402,7 +423,7 @@
     "__type__": "class",
     "name": "90.0 100.0",
     "group": "SNOWDEPTH-ANOMALY-AVERAGE",
-    "expression": "([pixel] >= 90.0)",
+    "expression": "([pixel] >= 90.0 AND [pixel] < 100.0)",
     "style": {
       "__type__": "style",
       "colorrange": [
@@ -415,6 +436,27 @@
       ],
       "datarange": [
         90.0,
+        100.0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": "> 100.0",
+    "group": "SNOWDEPTH-ANOMALY-AVERAGE",
+    "expression": "([pixel] >= 100.0)",
+    "style": {
+      "__type__": "style",
+      "colorrange": [
+        5,
+        48,
+        97,
+        5,
+        48,
+        97
+      ],
+      "datarange": [
+        100.0,
         1000.0
       ]
     }

--- a/geomet_climate/resources/mapserv/class/spei.json
+++ b/geomet_climate/resources/mapserv/class/spei.json
@@ -1,7 +1,7 @@
 [
  {
     "__type__": "class",
-    "name": "(-3.0) — (-2.5)",
+    "name": "< -2.5",
     "group": "SPEI",
     "expression": "([pixel] <  -2.5)",
     "style": {
@@ -15,7 +15,7 @@
   },
   {
     "__type__": "class",
-    "name": "(-2.5) — (-2.0)",
+    "name": "-2.5 -2.0",
     "group": "SPEI",
     "expression": "([pixel] >= -2.5 AND [pixel] <  -2.0)",
     "style": {
@@ -29,7 +29,7 @@
   },
   {
     "__type__": "class",
-    "name": "(-2.0) — (-1.5)",
+    "name": "-2.0 -1.5",
     "group": "SPEI",
     "expression": "([pixel] >= -2.0 AND [pixel] <  -1.5)",
     "style": {
@@ -43,7 +43,7 @@
   },
   {
     "__type__": "class",
-    "name": "(-1.5) — (-1.0)",
+    "name": "-1.5 -1.0",
     "group": "SPEI",
     "expression": "([pixel] >= -1.5 AND [pixel] <  -1.0)",
     "style": {
@@ -57,7 +57,7 @@
   },
   {
     "__type__": "class",
-    "name": "(-1.0) — (-0.5)",
+    "name": "-1.0 -0.5",
     "group": "SPEI",
     "expression": "([pixel] >= -1.0 AND [pixel] < -0.5)",
     "style": {
@@ -71,7 +71,7 @@
   },
   {
     "__type__": "class",
-    "name": "(-0.5) — 0.0",
+    "name": "-0.5  0.0",
     "group": "SPEI",
     "expression": "([pixel] >= -0.5 AND [pixel] <  0.0)",
     "style": {
@@ -155,7 +155,7 @@
   },
   {
     "__type__": "class",
-    "name": "2.5 — 3",
+    "name": ">= 2.5",
     "group": "SPEI",
     "expression": "([pixel] >= 2.5)",
     "style": {

--- a/geomet_climate/resources/mapserv/class/temp_absolute.json
+++ b/geomet_climate/resources/mapserv/class/temp_absolute.json
@@ -1,7 +1,7 @@
 [
   {
     "__type__": "class",
-    "name": "-33.0 -30.0",
+    "name": "<  -30.0",
     "group": "TEMP-ABSOLUTE",
     "expression": "([pixel] <  -30.0)",
     "style": {
@@ -442,7 +442,7 @@
   },
   {
     "__type__": "class",
-    "name": "30.0 33.0",
+    "name": ">= 30.0",
     "group": "TEMP-ABSOLUTE",
     "expression": "([pixel] >= 30.0)",
     "style": {

--- a/geomet_climate/resources/mapserv/class/temp_anomalies.json
+++ b/geomet_climate/resources/mapserv/class/temp_anomalies.json
@@ -1,6 +1,25 @@
-
-
 [
+  {
+    "__type__": "class",
+    "name": "< -2.5",
+    "group": "TEMP-ANOMALIES",
+    "expression": "([pixel] < -2.5)",
+    "style": {
+      "__type__": "style",
+      "colorrange": [
+        10,
+        40,
+        100,
+        10,
+        40,
+        100
+      ],
+      "datarange": [
+        -15.0,
+        -2.5
+      ]
+    }
+  },
   {
     "__type__": "class",
     "name": "-2.5 -1.5",
@@ -17,7 +36,7 @@
         217
       ],
       "datarange": [
-        -15,
+        -2.5,
         -1.5
       ]
     }
@@ -612,7 +631,7 @@
   },
   {
     "__type__": "class",
-    "name": "12.5 13",
+    "name": ">= 12.5",
     "group": "TEMP-ANOMALIES",
     "expression": "([pixel] >= 12.5)",
     "style": {

--- a/geomet_climate/resources/mapserv/class/tn20.json
+++ b/geomet_climate/resources/mapserv/class/tn20.json
@@ -1,7 +1,7 @@
 [
   {
     "__type__": "class",
-    "name": "5",
+    "name": "< 5",
     "group": "TN20",
     "expression": "([pixel] < 5)",
     "style": {

--- a/geomet_climate/resources/mapserv/class/tx30.json
+++ b/geomet_climate/resources/mapserv/class/tx30.json
@@ -1,7 +1,7 @@
 [
   {
     "__type__": "class",
-    "name": "5",
+    "name": "< 5",
     "group": "TX30",
     "expression": "([pixel] < 5)",
     "style": {

--- a/geomet_climate/resources/mapserv/class/wind_absolute.json
+++ b/geomet_climate/resources/mapserv/class/wind_absolute.json
@@ -171,7 +171,7 @@
     "__type__": "class",
     "name": "16.0 18.0",
     "group": "SFCWINDSPEED-ABSOLUTE",
-    "expression": "([pixel] >= 16.0)",
+    "expression": "([pixel] >= 16.0 AND [pixel] <  18.0)",
     "style": {
       "__type__": "style",
       "colorrange": [
@@ -184,6 +184,27 @@
       ],
       "datarange": [
         16.0,
+        18.0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": ">= 18.0",
+    "group": "SFCWINDSPEED-ABSOLUTE",
+    "expression": "([pixel] >= 18.0)",
+    "style": {
+      "__type__": "style",
+      "colorrange": [
+        103,
+        0,
+        31,
+        103,
+        0,
+        31
+      ],
+      "datarange": [
+        18.0,
         45.0
       ]
     }

--- a/geomet_climate/resources/mapserv/class/wind_anomaly.json
+++ b/geomet_climate/resources/mapserv/class/wind_anomaly.json
@@ -1,9 +1,30 @@
 [
   {
     "__type__": "class",
+    "name": "< -30.0",
+    "group": "SFCWINDSPEED-ANOMALY",
+    "expression": "([pixel] <  -30.0)",
+    "style": {
+      "__type__": "style",
+      "colorrange": [
+        18,
+        74,
+        134,
+        18,
+        74,
+        134
+      ],
+      "datarange": [
+        -45.0,
+        -30.0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
     "name": "-30.0 -27.0",
     "group": "SFCWINDSPEED-ANOMALY",
-    "expression": "([pixel] <  -27.0)",
+    "expression": "([pixel] >= -30.0 AND [pixel] <  -27.0)",
     "style": {
       "__type__": "style",
       "colorrange": [
@@ -15,7 +36,7 @@
         97
       ],
       "datarange": [
-        -45.0,
+        -30.0,
         -27.0
       ]
     }
@@ -402,7 +423,7 @@
     "__type__": "class",
     "name": "27.0 30.0",
     "group": "SFCWINDSPEED-ANOMALY",
-    "expression": "([pixel] >=  27.0)",
+    "expression": "([pixel] >= 27.0 AND [pixel] <  30.0)",
     "style": {
       "__type__": "style",
       "colorrange": [
@@ -415,6 +436,27 @@
       ],
       "datarange": [
         27.0,
+        30.0
+      ]
+    }
+  },
+  {
+    "__type__": "class",
+    "name": ">= 30.0",
+    "group": "SFCWINDSPEED-ANOMALY",
+    "expression": "([pixel] >= 30.0)",
+    "style": {
+      "__type__": "style",
+      "colorrange": [
+        140,
+        12,
+        37,
+        140,
+        12,
+        37
+      ],
+      "datarange": [
+        30.0,
         60.0
       ]
     }


### PR DESCRIPTION
See ticket #1444 in msc-geomet, now closer to the generate legends script from GeoMet-Weather.
- Allow close-ended classes for discrete legends by removing the forced extend `extend='both'`.
- Allow open-ended classes for linear legends by allowing `<, <=, >, >= `symbols in `name.`
